### PR TITLE
ffac-Optik-Pfennigs in Segment 7

### DIFF
--- a/segment-07/30b5c2567ba7-ffac-Optik-Pfennigs
+++ b/segment-07/30b5c2567ba7-ffac-Optik-Pfennigs
@@ -1,0 +1,1 @@
+key "efe0e5f3d3c6cadbebe9922b61e44cf1106c3d64a4cfb3738328af1a4581a53a";


### PR DESCRIPTION
Mesht mit ffac-InterSport-Schaefer, welcher schon in Segment 7 ist
